### PR TITLE
Implement JitBuilder type coercion services

### DIFF
--- a/compiler/ilgen/IlBuilder.cpp
+++ b/compiler/ilgen/IlBuilder.cpp
@@ -1007,6 +1007,31 @@ IlBuilder::convertTo(TR::IlType *t, TR::IlValue *v, bool needUnsigned)
    return convertedValue;
    }
 
+static TR::ILOpCodes
+getCoercionOpcode(TR::DataType fromType, TR::DataType toType)
+   {
+   if (fromType == TR::Int32 && toType == TR::Float) return TR::ibits2f;
+   else if (fromType == TR::Float && toType == TR::Int32) return TR::fbits2i;
+   else if (fromType == TR::Int64 && toType == TR::Double) return TR::lbits2d;
+   else if (fromType == TR::Double && toType == TR::Int64) return TR::dbits2l;
+   else return TR::BadILOp;
+   }
+
+TR::IlValue*
+IlBuilder::CoerceTo(TR::IlType* t, TR::IlValue* v)
+   {
+   TR::DataType typeFrom = v->getDataType();
+   TR::DataType typeTo = t->getPrimitiveType();
+
+   TR::ILOpCodes coerceOpcode = getCoercionOpcode(typeFrom, typeTo);
+   TR_ASSERT(coerceOpcode != TR::BadILOp, "Builder [ %p ] unknown coercion requested for value %d (TR::DataType %d) to type %s", this, v->getID(), (int)typeFrom, t->getName());
+
+   TR::Node *result = TR::Node::create(coerceOpcode, 1, loadValue(v));
+   TR::IlValue *coercedValue = newValue(t, result);
+   TraceIL("IlBuilder[ %p ]::%d is CoerceTo(%s) %d\n", this, coercedValue->getID(), t->getName(), v->getID());
+   return coercedValue;
+   }
+
 TR::IlValue *
 IlBuilder::unaryOp(TR::ILOpCodes op, TR::IlValue *v)
    {

--- a/compiler/ilgen/IlBuilder.hpp
+++ b/compiler/ilgen/IlBuilder.hpp
@@ -198,6 +198,18 @@ public:
    TR::IlValue *ConvertTo(TR::IlType *t, TR::IlValue *v);
    TR::IlValue *UnsignedConvertTo(TR::IlType *t, TR::IlValue *v);
 
+   /**
+    * @brief Coerce an IlValue to a given type
+    * @param type is the target type of the coercion
+    * @param value is the value to be coerced
+    * @return the IlValue coerced to the specified type
+    *
+    * This service acts as a kind of `reinterpret_cast` for JitBuilder IlValues.
+    * Given some input value, it produces a new value that represents the same
+    * bit pattern as the original one, but with a different type.
+    */
+   TR::IlValue* CoerceTo(TR::IlType* type, TR::IlValue* value);
+
    // memory
    TR::IlValue *CreateLocalArray(int32_t numElements, TR::IlType *elementType);
    TR::IlValue *CreateLocalStruct(TR::IlType *structType);


### PR DESCRIPTION
This commit adds the `CoerceTo` service to JitBuilder. It allows an integer value's bit pattern to be reinterpreted as a floating point value and vice versa. It maps directly to the following Testarossa opcodes:

- `ibits2f`
- `fbits2i`
- `lbits2d`
- `dbits2l`

Signed-off-by: Leonardo Banderali <leob@linux.vnet.ibm.com>